### PR TITLE
feat: MCP server source control + 5 new session tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,20 @@ Thumbs.db
 
 # Session context (user-generated, not repo content)
 session-context/
+
+# Claude Code runtime artifacts
+.claude/
+.playwright-mcp/
+.taskmaster/
+
+# Internal process artifacts (never commit)
+chatGPTConvo*.md
+doubt*.md
+*-current.md
+docs/archive/
+
+# Nested clone — not a submodule, excluded intentionally
+atlas-session-lifecycle/
+
+# Phase 0 cleanup artifacts
+stop-skill-save-pause.patch

--- a/install.sh
+++ b/install.sh
@@ -362,6 +362,19 @@ install_skill() {
         else
             die "scripts/session-init.py not found in repository."
         fi
+
+        # Deploy MCP server source (atlas-session MCP package)
+        if [[ -d "${src_dir}/src/atlas_session" ]]; then
+            mkdir -p "${SKILL_DIR}/src"
+            rm -rf "${SKILL_DIR}/src/atlas_session"
+            cp -r "${src_dir}/src/atlas_session" "${SKILL_DIR}/src/atlas_session"
+            if [[ -f "${src_dir}/src/pyproject.toml" ]]; then
+                cp "${src_dir}/src/pyproject.toml" "${SKILL_DIR}/src/pyproject.toml"
+            fi
+            ok "Installed MCP server (src/atlas_session/)"
+        else
+            warn "src/atlas_session/ not found — MCP server not installed"
+        fi
     fi
 
     # Install templates

--- a/src/atlas_session/__init__.py
+++ b/src/atlas_session/__init__.py
@@ -1,0 +1,3 @@
+"""Atlas Session Lifecycle — MCP Server for AI session management."""
+
+__version__ = "4.0.0"

--- a/src/atlas_session/__main__.py
+++ b/src/atlas_session/__main__.py
@@ -1,0 +1,5 @@
+"""Allow running as `python -m atlas_session`."""
+
+from .server import main
+
+main()

--- a/src/atlas_session/common/__init__.py
+++ b/src/atlas_session/common/__init__.py
@@ -1,0 +1,1 @@
+"""Common utilities for atlas-session-lifecycle."""

--- a/src/atlas_session/common/config.py
+++ b/src/atlas_session/common/config.py
@@ -1,0 +1,74 @@
+"""Configuration from environment variables and defaults."""
+
+import os
+from pathlib import Path
+
+# Template resolution: plugin bundled templates > home dir fallback
+_pkg_root = Path(__file__).resolve().parent.parent.parent.parent  # up to plugin root
+_plugin_templates = _pkg_root / "templates"
+_home_templates = Path.home() / "claude-session-init-templates"
+
+TEMPLATE_DIR = _plugin_templates if _plugin_templates.is_dir() else _home_templates
+
+SESSION_DIR_NAME = "session-context"
+CLAUDE_MD_NAME = "CLAUDE.md"
+GOVERNANCE_CACHE_PATH = Path("/tmp/claude-governance-cache.json")
+LIFECYCLE_STATE_FILENAME = ".lifecycle-active.json"
+
+ATLASCOIN_URL = os.environ.get("ATLASCOIN_URL", "http://localhost:3000")
+
+REQUIRED_TEMPLATES = [
+    "CLAUDE-activeContext.md",
+    "CLAUDE-decisions.md",
+    "CLAUDE-patterns.md",
+    "CLAUDE-soul-purpose.md",
+    "CLAUDE-troubleshooting.md",
+    "CLAUDE-mdReference.md",
+]
+
+SESSION_FILES = [
+    "CLAUDE-activeContext.md",
+    "CLAUDE-decisions.md",
+    "CLAUDE-patterns.md",
+    "CLAUDE-soul-purpose.md",
+    "CLAUDE-troubleshooting.md",
+]
+
+GOVERNANCE_SECTIONS = {
+    "Structure Maintenance Rules": """\
+## Structure Maintenance Rules
+
+> These rules ensure the project stays organized across sessions.
+
+- **CLAUDE.md** stays at root (Claude Code requirement)
+- **Session context** files live in `session-context/` - NEVER at root
+- **Scripts** (.sh, .ps1, .py, .js, .ts) go in `scripts/<category>/`
+- **Documentation** (.md, .txt guides/reports) go in `docs/<category>/`
+- **Config** files (.json, .yaml, .toml) go in `config/` unless framework-required at root
+- **Logs** go in `logs/`
+- When creating new files, place them in the correct category directory
+- Do NOT dump new files at root unless they are actively being worked on
+- Periodically review root for stale files and move to correct category""",
+
+    "Session Context Files": """\
+## Session Context Files (MUST maintain)
+
+After every session, update these files in `session-context/` with timestamp and reasoning:
+
+- `session-context/CLAUDE-activeContext.md` - Current session state, goals, progress
+- `session-context/CLAUDE-decisions.md` - Architecture decisions and rationale
+- `session-context/CLAUDE-patterns.md` - Established code patterns and conventions
+- `session-context/CLAUDE-troubleshooting.md` - Common issues and proven solutions""",
+
+    "IMMUTABLE TEMPLATE RULES": """\
+## IMMUTABLE TEMPLATE RULES
+
+> **DO NOT** edit the template files bundled with the plugin.
+> Templates are immutable source-of-truth. Only edit the copies in your project.""",
+
+    "Ralph Loop": """\
+## Ralph Loop
+
+**Mode**: {ralph_mode}
+**Intensity**: {ralph_intensity}""",
+}

--- a/src/atlas_session/common/state.py
+++ b/src/atlas_session/common/state.py
@@ -1,0 +1,64 @@
+"""File-based state helpers for session-context/ directory."""
+
+import json
+from pathlib import Path
+
+from .config import SESSION_DIR_NAME, CLAUDE_MD_NAME
+
+
+def session_dir(project_dir: str) -> Path:
+    return Path(project_dir) / SESSION_DIR_NAME
+
+
+def claude_md(project_dir: str) -> Path:
+    return Path(project_dir) / CLAUDE_MD_NAME
+
+
+def parse_md_sections(content: str) -> dict[str, str]:
+    """Parse markdown into {heading: content} by ## headings.
+
+    Handles code blocks correctly — ignores ## inside ``` fences.
+    """
+    sections: dict[str, str] = {}
+    current_heading: str | None = None
+    current_lines: list[str] = []
+    in_code_block = False
+
+    for line in content.split("\n"):
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            in_code_block = not in_code_block
+
+        if not in_code_block and line.startswith("## ") and not line.startswith("### "):
+            if current_heading:
+                sections[current_heading] = "\n".join(current_lines)
+            current_heading = line.strip()
+            current_lines = [line]
+        else:
+            current_lines.append(line)
+
+    if current_heading:
+        sections[current_heading] = "\n".join(current_lines)
+
+    return sections
+
+
+def find_section(sections: dict[str, str], key: str) -> tuple[str | None, str | None]:
+    """Find a section by partial case-insensitive match."""
+    for heading, body in sections.items():
+        if key.lower() in heading.lower():
+            return heading, body
+    return None, None
+
+
+def read_json(path: Path) -> dict:
+    """Read a JSON file, return empty dict on failure."""
+    try:
+        return json.loads(path.read_text())
+    except Exception:
+        return {}
+
+
+def write_json(path: Path, data: dict) -> None:
+    """Write dict as pretty JSON."""
+    path.write_text(json.dumps(data, indent=2))

--- a/src/atlas_session/contract/__init__.py
+++ b/src/atlas_session/contract/__init__.py
@@ -1,0 +1,1 @@
+"""Contract and bounty domain."""

--- a/src/atlas_session/contract/atlascoin.py
+++ b/src/atlas_session/contract/atlascoin.py
@@ -1,0 +1,86 @@
+"""AtlasCoin HTTP client for bounty operations."""
+
+from __future__ import annotations
+
+import httpx
+
+from ..common.config import ATLASCOIN_URL
+
+
+async def health() -> dict:
+    """Check AtlasCoin service availability."""
+    try:
+        async with httpx.AsyncClient(timeout=5) as client:
+            r = await client.get(f"{ATLASCOIN_URL}/health")
+            if r.status_code == 200:
+                return {"healthy": True, "url": ATLASCOIN_URL, "data": r.json() if r.headers.get("content-type", "").startswith("application/json") else {}}
+            return {"healthy": False, "url": ATLASCOIN_URL, "status_code": r.status_code}
+    except Exception as e:
+        return {"healthy": False, "url": ATLASCOIN_URL, "error": str(e)}
+
+
+async def create_bounty(soul_purpose: str, escrow: int) -> dict:
+    """Create a bounty on AtlasCoin."""
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            r = await client.post(
+                f"{ATLASCOIN_URL}/api/bounties",
+                json={
+                    "poster": "session-lifecycle",
+                    "template": soul_purpose,
+                    "escrowAmount": escrow,
+                },
+            )
+            return {"status": "ok", "data": r.json()} if r.status_code in (200, 201) else {"status": "error", "status_code": r.status_code, "body": r.text}
+    except Exception as e:
+        return {"status": "error", "error": str(e)}
+
+
+async def get_bounty(bounty_id: str) -> dict:
+    """Get bounty status."""
+    try:
+        async with httpx.AsyncClient(timeout=5) as client:
+            r = await client.get(f"{ATLASCOIN_URL}/api/bounties/{bounty_id}")
+            return {"status": "ok", "data": r.json()} if r.status_code == 200 else {"status": "error", "status_code": r.status_code}
+    except Exception as e:
+        return {"status": "error", "error": str(e)}
+
+
+async def submit_solution(bounty_id: str, stake: int, evidence: dict) -> dict:
+    """Submit a solution for verification."""
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            r = await client.post(
+                f"{ATLASCOIN_URL}/api/bounties/{bounty_id}/submit",
+                json={
+                    "claimant": "session-agent",
+                    "stakeAmount": stake,
+                    "evidence": evidence,
+                },
+            )
+            return {"status": "ok", "data": r.json()} if r.status_code in (200, 201) else {"status": "error", "status_code": r.status_code, "body": r.text}
+    except Exception as e:
+        return {"status": "error", "error": str(e)}
+
+
+async def verify_bounty(bounty_id: str, evidence: dict) -> dict:
+    """Submit verification evidence."""
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            r = await client.post(
+                f"{ATLASCOIN_URL}/api/bounties/{bounty_id}/verify",
+                json={"evidence": evidence},
+            )
+            return {"status": "ok", "data": r.json()} if r.status_code in (200, 201) else {"status": "error", "status_code": r.status_code, "body": r.text}
+    except Exception as e:
+        return {"status": "error", "error": str(e)}
+
+
+async def settle_bounty(bounty_id: str) -> dict:
+    """Settle a verified bounty — distribute tokens."""
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            r = await client.post(f"{ATLASCOIN_URL}/api/bounties/{bounty_id}/settle")
+            return {"status": "ok", "data": r.json()} if r.status_code in (200, 201) else {"status": "error", "status_code": r.status_code, "body": r.text}
+    except Exception as e:
+        return {"status": "error", "error": str(e)}

--- a/src/atlas_session/contract/model.py
+++ b/src/atlas_session/contract/model.py
@@ -1,0 +1,82 @@
+"""Contract data model — deterministic criteria for bounty verification.
+
+Contracts define "done" as executable criteria at creation time.
+At verification, just run them — no AI judgment needed.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from pathlib import Path
+
+
+class CriterionType(str, Enum):
+    SHELL = "shell"                    # Run command, check exit code
+    CONTEXT_CHECK = "context_check"    # Check read-context JSON field
+    FILE_EXISTS = "file_exists"        # Check file/dir exists
+    GIT_CHECK = "git_check"            # Check git state
+
+
+@dataclass
+class Criterion:
+    name: str
+    type: CriterionType
+    pass_when: str                     # "exit_code == 0", "== 0", "not_empty"
+    command: str | None = None         # Shell command (shell/git_check)
+    field: str | None = None           # Context field (context_check)
+    path: str | None = None            # File path (file_exists)
+    weight: float = 1.0
+
+    def to_dict(self) -> dict:
+        d = asdict(self)
+        d["type"] = self.type.value
+        return d
+
+    @classmethod
+    def from_dict(cls, data: dict) -> Criterion:
+        data = dict(data)
+        data["type"] = CriterionType(data["type"])
+        return cls(**data)
+
+
+@dataclass
+class Contract:
+    soul_purpose: str
+    escrow: int
+    criteria: list[Criterion] = field(default_factory=list)
+    bounty_id: str = ""
+    status: str = "draft"              # draft | active | submitted | verified | settled | forfeited
+
+    def to_dict(self) -> dict:
+        return {
+            "soul_purpose": self.soul_purpose,
+            "escrow": self.escrow,
+            "criteria": [c.to_dict() for c in self.criteria],
+            "bounty_id": self.bounty_id,
+            "status": self.status,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> Contract:
+        data = dict(data)
+        data["criteria"] = [Criterion.from_dict(c) for c in data.get("criteria", [])]
+        return cls(**data)
+
+    def save(self, project_dir: str) -> Path:
+        """Save contract to session-context/contract.json."""
+        path = Path(project_dir) / "session-context" / "contract.json"
+        path.write_text(json.dumps(self.to_dict(), indent=2))
+        return path
+
+    @classmethod
+    def load(cls, project_dir: str) -> Contract | None:
+        """Load contract from session-context/contract.json."""
+        path = Path(project_dir) / "session-context" / "contract.json"
+        if not path.is_file():
+            return None
+        try:
+            return cls.from_dict(json.loads(path.read_text()))
+        except Exception:
+            return None

--- a/src/atlas_session/contract/tools.py
+++ b/src/atlas_session/contract/tools.py
@@ -1,0 +1,293 @@
+"""Contract & bounty MCP tool definitions.
+
+Deterministic bounty management — contracts define executable test
+criteria at creation time, verification just runs them.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastmcp import FastMCP
+
+from . import atlascoin
+from .model import Contract, Criterion, CriterionType
+from .verifier import run_tests
+
+
+def register(mcp: FastMCP) -> None:
+    """Register all contract tools on the given server."""
+
+    @mcp.tool
+    async def contract_health() -> dict:
+        """Check AtlasCoin service availability. Call before any bounty
+        operations. Returns {healthy, url}."""
+        return await atlascoin.health()
+
+    @mcp.tool
+    async def contract_create(
+        project_dir: str,
+        soul_purpose: str,
+        escrow: int,
+        criteria: list[dict],
+    ) -> dict:
+        """Create a bounty with executable test criteria.
+
+        Each criterion dict needs: name, type (shell|context_check|
+        file_exists|git_check), pass_when, and optionally command/field/path.
+
+        Creates both an AtlasCoin bounty (if available) and a local
+        contract.json in session-context/.
+        """
+        parsed = []
+        for c in criteria:
+            try:
+                parsed.append(Criterion.from_dict(c))
+            except Exception as e:
+                return {"status": "error", "message": f"Invalid criterion '{c.get('name', '?')}': {e}"}
+
+        contract = Contract(
+            soul_purpose=soul_purpose,
+            escrow=escrow,
+            criteria=parsed,
+        )
+
+        # Try AtlasCoin
+        api_result = await atlascoin.create_bounty(soul_purpose, escrow)
+        if api_result.get("status") == "ok":
+            bounty_data = api_result.get("data", {})
+            bounty_id = str(bounty_data.get("id", bounty_data.get("bountyId", "")))
+            contract.bounty_id = bounty_id
+            contract.status = "active"
+
+            # Write BOUNTY_ID.txt for backward compatibility
+            bid_path = Path(project_dir) / "session-context" / "BOUNTY_ID.txt"
+            bid_path.write_text(bounty_id)
+        else:
+            contract.status = "active_local"
+
+        contract.save(project_dir)
+
+        return {
+            "status": "ok",
+            "bounty_id": contract.bounty_id,
+            "contract_status": contract.status,
+            "criteria_count": len(parsed),
+            "atlascoin": api_result.get("status") == "ok",
+        }
+
+    @mcp.tool
+    async def contract_get_status(project_dir: str) -> dict:
+        """Get current contract and bounty status."""
+        contract = Contract.load(project_dir)
+        if not contract:
+            return {"status": "none", "message": "No contract found"}
+
+        result = contract.to_dict()
+
+        if contract.bounty_id:
+            api_status = await atlascoin.get_bounty(contract.bounty_id)
+            result["atlascoin_status"] = api_status
+
+        return result
+
+    @mcp.tool
+    def contract_run_tests(project_dir: str) -> dict:
+        """Execute all contract criteria deterministically.
+
+        Runs each criterion (shell commands, context checks, file checks,
+        git checks) and returns pass/fail results. No AI judgment involved.
+        """
+        contract = Contract.load(project_dir)
+        if not contract:
+            return {"status": "error", "message": "No contract found"}
+
+        return run_tests(project_dir, contract)
+
+    @mcp.tool
+    async def contract_submit(project_dir: str, evidence: dict | None = None) -> dict:
+        """Submit solution to AtlasCoin for the active contract.
+        Optionally pass evidence dict; defaults to test run results."""
+        contract = Contract.load(project_dir)
+        if not contract or not contract.bounty_id:
+            return {"status": "error", "message": "No active bounty"}
+
+        if evidence is None:
+            test_results = run_tests(project_dir, contract)
+            evidence = {
+                "soul_purpose": contract.soul_purpose,
+                "test_results": test_results,
+            }
+
+        stake = int(contract.escrow * 0.1)
+        result = await atlascoin.submit_solution(contract.bounty_id, stake, evidence)
+
+        if result.get("status") == "ok":
+            contract.status = "submitted"
+            contract.save(project_dir)
+
+        return result
+
+    @mcp.tool
+    async def contract_verify(project_dir: str) -> dict:
+        """Run deterministic verification: execute all criteria tests,
+        then submit pass/fail to AtlasCoin."""
+        contract = Contract.load(project_dir)
+        if not contract:
+            return {"status": "error", "message": "No contract found"}
+
+        # Run tests locally
+        test_results = run_tests(project_dir, contract)
+
+        verification = {
+            "passed": test_results["all_passed"],
+            "score": test_results["score"],
+            "details": test_results["results"],
+            "summary": test_results["summary"],
+        }
+
+        # Submit to AtlasCoin if bounty exists
+        if contract.bounty_id:
+            api_result = await atlascoin.verify_bounty(contract.bounty_id, verification)
+            verification["atlascoin"] = api_result
+
+        if test_results["all_passed"]:
+            contract.status = "verified"
+        else:
+            contract.status = "failed_verification"
+        contract.save(project_dir)
+
+        return verification
+
+    @mcp.tool
+    async def contract_settle(project_dir: str) -> dict:
+        """Settle a verified bounty — distribute tokens."""
+        contract = Contract.load(project_dir)
+        if not contract or not contract.bounty_id:
+            return {"status": "error", "message": "No active bounty to settle"}
+
+        result = await atlascoin.settle_bounty(contract.bounty_id)
+
+        if result.get("status") == "ok":
+            contract.status = "settled"
+            contract.save(project_dir)
+
+        return result
+
+    @mcp.tool
+    def contract_draft_criteria(
+        soul_purpose: str,
+        project_signals: dict | None = None,
+    ) -> dict:
+        """Suggest deterministic criteria based on soul purpose and project
+        signals. Returns suggested criteria for AI to present to user.
+        This is the only place AI judgment is involved in contracts."""
+        suggestions: list[dict] = []
+
+        # Always suggest: has commits
+        suggestions.append({
+            "name": "has_commits",
+            "type": "git_check",
+            "command": "git log --oneline -1",
+            "pass_when": "exit_code == 0",
+            "weight": 1.0,
+        })
+
+        # Always suggest: no open tasks
+        suggestions.append({
+            "name": "no_open_tasks",
+            "type": "context_check",
+            "field": "open_tasks",
+            "pass_when": "== 0",
+            "weight": 1.0,
+        })
+
+        # Detect test-related soul purposes
+        test_keywords = {"test", "tests", "testing", "tdd", "coverage", "spec"}
+        if any(kw in soul_purpose.lower() for kw in test_keywords):
+            suggestions.append({
+                "name": "tests_pass",
+                "type": "shell",
+                "command": _guess_test_command(project_signals),
+                "pass_when": "exit_code == 0",
+                "weight": 2.0,
+            })
+
+        # Detect build/deploy soul purposes
+        build_keywords = {"build", "deploy", "compile", "bundle"}
+        if any(kw in soul_purpose.lower() for kw in build_keywords):
+            suggestions.append({
+                "name": "build_succeeds",
+                "type": "shell",
+                "command": _guess_build_command(project_signals),
+                "pass_when": "exit_code == 0",
+                "weight": 2.0,
+            })
+
+        # If project has detected stack, suggest lint
+        if project_signals and project_signals.get("detected_stack"):
+            suggestions.append({
+                "name": "lint_clean",
+                "type": "shell",
+                "command": _guess_lint_command(project_signals),
+                "pass_when": "exit_code == 0",
+                "weight": 0.5,
+            })
+
+        # Session context must exist
+        suggestions.append({
+            "name": "session_context_exists",
+            "type": "file_exists",
+            "path": "session-context/CLAUDE-activeContext.md",
+            "pass_when": "not_empty",
+            "weight": 0.5,
+        })
+
+        return {
+            "suggested_criteria": suggestions,
+            "soul_purpose": soul_purpose,
+            "note": "Review and modify criteria before creating contract. Remove inapplicable criteria and adjust commands for your project.",
+        }
+
+
+def _guess_test_command(signals: dict | None) -> str:
+    if not signals:
+        return "echo 'No test command configured'"
+    stack = signals.get("detected_stack", [])
+    if "node" in stack:
+        return "npm test"
+    if "python" in stack:
+        return "pytest"
+    if "rust" in stack:
+        return "cargo test"
+    if "go" in stack:
+        return "go test ./..."
+    return "echo 'No test command configured'"
+
+
+def _guess_build_command(signals: dict | None) -> str:
+    if not signals:
+        return "echo 'No build command configured'"
+    stack = signals.get("detected_stack", [])
+    if "node" in stack:
+        return "npm run build"
+    if "rust" in stack:
+        return "cargo build"
+    if "go" in stack:
+        return "go build ./..."
+    return "echo 'No build command configured'"
+
+
+def _guess_lint_command(signals: dict | None) -> str:
+    if not signals:
+        return "echo 'No lint command configured'"
+    stack = signals.get("detected_stack", [])
+    if "node" in stack:
+        return "npm run lint"
+    if "python" in stack:
+        return "ruff check ."
+    if "rust" in stack:
+        return "cargo clippy"
+    if "go" in stack:
+        return "go vet ./..."
+    return "echo 'No lint command configured'"

--- a/src/atlas_session/contract/verifier.py
+++ b/src/atlas_session/contract/verifier.py
@@ -1,0 +1,185 @@
+"""Deterministic test runner for contract criteria.
+
+Runs each criterion and returns pass/fail results — no AI judgment.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from ..session.operations import read_context
+from .model import Contract, CriterionType
+
+
+def run_tests(project_dir: str, contract: Contract) -> dict:
+    """Execute all criteria deterministically. Returns structured results."""
+    results: list[dict] = []
+    total_weight = 0.0
+    passed_weight = 0.0
+
+    for criterion in contract.criteria:
+        result = _run_one(project_dir, criterion, contract)
+        results.append(result)
+        total_weight += criterion.weight
+        if result["passed"]:
+            passed_weight += criterion.weight
+
+    all_passed = all(r["passed"] for r in results)
+    score = (passed_weight / total_weight * 100) if total_weight > 0 else 0
+
+    return {
+        "results": results,
+        "all_passed": all_passed,
+        "score": round(score, 1),
+        "summary": f"{sum(1 for r in results if r['passed'])}/{len(results)} criteria passed ({score:.0f}%)",
+    }
+
+
+def _run_one(project_dir: str, criterion, contract: Contract) -> dict:
+    """Run a single criterion and return result dict."""
+    name = criterion.name
+    ctype = criterion.type
+    pass_when = criterion.pass_when
+
+    try:
+        if ctype == CriterionType.SHELL:
+            return _run_shell(project_dir, name, criterion.command or "", pass_when, criterion.weight)
+        elif ctype == CriterionType.CONTEXT_CHECK:
+            return _run_context_check(project_dir, name, criterion.field or "", pass_when, criterion.weight)
+        elif ctype == CriterionType.FILE_EXISTS:
+            return _run_file_exists(project_dir, name, criterion.path or "", pass_when, criterion.weight)
+        elif ctype == CriterionType.GIT_CHECK:
+            return _run_shell(project_dir, name, criterion.command or "", pass_when, criterion.weight)
+        else:
+            return {"name": name, "passed": False, "output": f"Unknown type: {ctype}", "weight": criterion.weight}
+    except Exception as e:
+        return {"name": name, "passed": False, "output": str(e), "weight": criterion.weight}
+
+
+def _run_shell(project_dir: str, name: str, command: str, pass_when: str, weight: float) -> dict:
+    """Run a shell command, evaluate pass_when against exit code."""
+    if not command:
+        return {"name": name, "passed": False, "output": "No command specified", "weight": weight}
+
+    try:
+        proc = subprocess.run(
+            command,
+            shell=True,
+            cwd=project_dir,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        output = (proc.stdout + proc.stderr).strip()[:500]
+        passed = _evaluate_pass_when(pass_when, exit_code=proc.returncode, output=output)
+    except subprocess.TimeoutExpired:
+        output = "Command timed out after 120s"
+        passed = False
+    except Exception as e:
+        output = str(e)
+        passed = False
+
+    return {"name": name, "passed": passed, "output": output, "weight": weight}
+
+
+def _run_context_check(project_dir: str, name: str, field_name: str, pass_when: str, weight: float) -> dict:
+    """Check a field from read_context output."""
+    ctx = read_context(project_dir)
+    value = ctx.get(field_name)
+
+    if value is None:
+        return {"name": name, "passed": False, "output": f"Field '{field_name}' not found", "weight": weight}
+
+    passed = _evaluate_pass_when(pass_when, value=value)
+    return {"name": name, "passed": passed, "output": f"{field_name} = {value}", "weight": weight}
+
+
+def _run_file_exists(project_dir: str, name: str, path: str, pass_when: str, weight: float) -> dict:
+    """Check if a file or directory exists."""
+    full_path = Path(project_dir) / path
+    exists = full_path.exists()
+
+    if pass_when == "not_empty":
+        if full_path.is_dir():
+            passed = exists and any(full_path.iterdir())
+        elif full_path.is_file():
+            passed = exists and full_path.stat().st_size > 0
+        else:
+            passed = False
+    else:
+        passed = exists
+
+    return {"name": name, "passed": passed, "output": f"{'exists' if exists else 'missing'}: {path}", "weight": weight}
+
+
+def _evaluate_pass_when(
+    pass_when: str,
+    exit_code: int | None = None,
+    value=None,
+    output: str = "",
+) -> bool:
+    """Evaluate a pass_when expression.
+
+    Supported expressions:
+    - "exit_code == 0"
+    - "== 0" (shorthand for numeric/count comparison)
+    - "> 0"
+    - "not_empty"
+    - "contains:<text>"
+    """
+    pw = pass_when.strip()
+
+    if pw == "not_empty":
+        if value is not None:
+            if isinstance(value, (list, dict)):
+                return len(value) > 0
+            return bool(value)
+        return bool(output)
+
+    if pw.startswith("contains:"):
+        text = pw[len("contains:"):]
+        if output:
+            return text in output
+        if isinstance(value, str):
+            return text in value
+        return False
+
+    if "exit_code" in pw:
+        if exit_code is None:
+            return False
+        # "exit_code == 0"
+        try:
+            op_val = pw.split("exit_code")[1].strip()
+            if op_val.startswith("=="):
+                return exit_code == int(op_val[2:].strip())
+            elif op_val.startswith("!="):
+                return exit_code != int(op_val[2:].strip())
+        except (ValueError, IndexError):
+            return False
+
+    # Shorthand numeric comparison: "== 0", "> 0", etc.
+    if pw.startswith("==") or pw.startswith("!=") or pw.startswith(">") or pw.startswith("<"):
+        compare_val = value
+        if compare_val is None and exit_code is not None:
+            compare_val = exit_code
+        if isinstance(compare_val, list):
+            compare_val = len(compare_val)
+        try:
+            num = float(compare_val) if compare_val is not None else 0
+            if pw.startswith("=="):
+                return num == float(pw[2:].strip())
+            elif pw.startswith("!="):
+                return num != float(pw[2:].strip())
+            elif pw.startswith(">="):
+                return num >= float(pw[2:].strip())
+            elif pw.startswith("<="):
+                return num <= float(pw[2:].strip())
+            elif pw.startswith(">"):
+                return num > float(pw[1:].strip())
+            elif pw.startswith("<"):
+                return num < float(pw[1:].strip())
+        except (ValueError, TypeError):
+            return False
+
+    return False

--- a/src/atlas_session/server.py
+++ b/src/atlas_session/server.py
@@ -1,0 +1,45 @@
+"""Atlas Session Lifecycle — FastMCP server entry point.
+
+Modular monolith: two domains (session + contract) registered on
+a single FastMCP server. Stateless tools, file-based state.
+
+Run:
+    python -m atlas_session.server              # stdio (Claude Code)
+    python -m atlas_session.server --transport http  # HTTP (remote)
+"""
+
+import sys
+
+from fastmcp import FastMCP
+
+from .session import tools as session_tools
+from .contract import tools as contract_tools
+
+mcp = FastMCP(
+    "Atlas Session Lifecycle",
+    version="4.0.0",
+    instructions=(
+        "MCP server for AI session lifecycle management. "
+        "Manages session context, soul purpose tracking, governance, "
+        "and deterministic contract-based bounty verification."
+    ),
+)
+
+# Register both domains
+session_tools.register(mcp)
+contract_tools.register(mcp)
+
+
+def main():
+    """Entry point for both `python -m atlas_session.server` and pip script."""
+    transport = "stdio"
+    if "--transport" in sys.argv:
+        idx = sys.argv.index("--transport")
+        if idx + 1 < len(sys.argv):
+            transport = sys.argv[idx + 1]
+
+    mcp.run(transport=transport)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/atlas_session/session/__init__.py
+++ b/src/atlas_session/session/__init__.py
@@ -1,0 +1,1 @@
+"""Session lifecycle domain."""

--- a/src/atlas_session/session/operations.py
+++ b/src/atlas_session/session/operations.py
@@ -1,0 +1,870 @@
+"""Core session lifecycle operations.
+
+Extracted from session-init.py — all logic preserved, adapted to be
+called as functions (not CLI subcommands) returning dicts instead of
+printing JSON.
+"""
+
+import json
+import shutil
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+from ..common.config import (
+    GOVERNANCE_CACHE_PATH,
+    GOVERNANCE_SECTIONS,
+    LIFECYCLE_STATE_FILENAME,
+    REQUIRED_TEMPLATES,
+    SESSION_FILES,
+    TEMPLATE_DIR,
+)
+from ..common.state import (
+    claude_md,
+    find_section,
+    parse_md_sections,
+    session_dir,
+)
+
+
+# ---------------------------------------------------------------------------
+# preflight
+# ---------------------------------------------------------------------------
+
+def preflight(project_dir: str) -> dict:
+    """Detect environment, return structured data."""
+    sd = session_dir(project_dir)
+    cmd = claude_md(project_dir)
+    root = Path(project_dir)
+
+    result: dict = {
+        "mode": "reconcile" if sd.is_dir() else "init",
+        "is_git": False,
+        "has_claude_md": cmd.is_file(),
+        "root_file_count": 0,
+        "templates_valid": False,
+        "template_count": 0,
+        "session_files": {},
+    }
+
+    # Git check
+    try:
+        subprocess.run(
+            ["git", "rev-parse", "--git-dir"],
+            capture_output=True, check=True, cwd=project_dir,
+        )
+        result["is_git"] = True
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        pass
+
+    # Root file count
+    root_files = [
+        f for f in root.iterdir()
+        if f.is_file() and not f.name.startswith("CLAUDE")
+    ]
+    result["root_file_count"] = len(root_files)
+
+    # Project signals
+    signals = _detect_project_signals(root, root_files)
+    result["project_signals"] = signals
+
+    # Template validation
+    existing = [f for f in REQUIRED_TEMPLATES if (TEMPLATE_DIR / f).is_file()]
+    result["template_count"] = len(existing)
+    result["templates_valid"] = len(existing) == len(REQUIRED_TEMPLATES)
+
+    # Session file validation (if reconcile)
+    if result["mode"] == "reconcile":
+        for f in SESSION_FILES:
+            path = sd / f
+            result["session_files"][f] = {
+                "exists": path.is_file(),
+                "has_content": path.is_file() and path.stat().st_size > 0,
+            }
+
+    return result
+
+
+def _detect_project_signals(root: Path, root_files: list[Path]) -> dict:
+    """Detect context for brainstorm weight classification."""
+    signals: dict = {
+        "has_readme": False,
+        "readme_excerpt": "",
+        "has_package_json": False,
+        "package_name": "",
+        "package_description": "",
+        "has_pyproject": False,
+        "has_cargo_toml": False,
+        "has_go_mod": False,
+        "has_code_files": False,
+        "detected_stack": [],
+        "is_empty_project": False,
+    }
+
+    # README detection
+    readme = root / "README.md"
+    if not readme.is_file():
+        readme = root / "readme.md"
+    if readme.is_file():
+        signals["has_readme"] = True
+        try:
+            lines = readme.read_text(errors="replace").split("\n")
+            content_lines = [
+                ln.strip() for ln in lines
+                if ln.strip() and not ln.strip().startswith("#")
+            ][:3]
+            signals["readme_excerpt"] = " ".join(content_lines)[:200]
+        except Exception:
+            pass
+
+    # package.json
+    pkg = root / "package.json"
+    if pkg.is_file():
+        signals["has_package_json"] = True
+        try:
+            data = json.loads(pkg.read_text(errors="replace"))
+            signals["package_name"] = data.get("name", "")
+            signals["package_description"] = data.get("description", "")
+        except Exception:
+            pass
+
+    # Stack marker files
+    if (root / "pyproject.toml").is_file():
+        signals["has_pyproject"] = True
+        signals["detected_stack"].append("python")
+    if (root / "Cargo.toml").is_file():
+        signals["has_cargo_toml"] = True
+        signals["detected_stack"].append("rust")
+    if (root / "go.mod").is_file():
+        signals["has_go_mod"] = True
+        signals["detected_stack"].append("go")
+    if signals["has_package_json"]:
+        signals["detected_stack"].append("node")
+
+    # Code file detection
+    code_exts = {".py", ".js", ".ts", ".rs", ".go", ".jsx", ".tsx"}
+    search_dirs = [root]
+    if (root / "src").is_dir():
+        search_dirs.append(root / "src")
+    for d in search_dirs:
+        try:
+            for f in d.iterdir():
+                if f.is_file() and f.suffix in code_exts:
+                    signals["has_code_files"] = True
+                    if f.suffix == ".py" and "python" not in signals["detected_stack"]:
+                        signals["detected_stack"].append("python")
+                    elif f.suffix in (".js", ".jsx", ".ts", ".tsx") and "node" not in signals["detected_stack"]:
+                        signals["detected_stack"].append("node")
+                    break
+        except PermissionError:
+            pass
+
+    # Empty project detection
+    has_manifests = any([
+        signals["has_readme"], signals["has_package_json"],
+        signals["has_pyproject"], signals["has_cargo_toml"],
+        signals["has_go_mod"],
+    ])
+    signals["is_empty_project"] = (
+        not signals["has_code_files"]
+        and not has_manifests
+        and len(root_files) <= 2
+    )
+
+    return signals
+
+
+# ---------------------------------------------------------------------------
+# init
+# ---------------------------------------------------------------------------
+
+def init(
+    project_dir: str,
+    soul_purpose: str,
+    ralph_mode: str = "Manual",
+    ralph_intensity: str = "",
+) -> dict:
+    """Bootstrap session-context with templates and soul purpose."""
+    sd = session_dir(project_dir)
+
+    if not TEMPLATE_DIR.is_dir():
+        return {"status": "error", "message": f"Templates dir missing at {TEMPLATE_DIR}"}
+
+    missing = [f for f in REQUIRED_TEMPLATES if not (TEMPLATE_DIR / f).is_file()]
+    if missing:
+        return {"status": "error", "message": f"Missing templates: {missing}"}
+
+    sd.mkdir(exist_ok=True)
+
+    # Copy templates (session files only)
+    for f in SESSION_FILES:
+        src = TEMPLATE_DIR / f
+        dst = sd / f
+        if src.is_file():
+            shutil.copy2(src, dst)
+
+    # Migrate old root-level files
+    root = Path(project_dir)
+    for f in SESSION_FILES:
+        root_file = root / f
+        session_file = sd / f
+        if root_file.is_file():
+            if not session_file.is_file():
+                root_file.rename(session_file)
+            else:
+                root_file.unlink()
+
+    # Write soul purpose
+    sp_file = sd / "CLAUDE-soul-purpose.md"
+    sp_file.write_text(f"# Soul Purpose\n\n{soul_purpose}\n")
+
+    # Seed active context
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    ac_file = sd / "CLAUDE-activeContext.md"
+    ac_file.write_text(
+        f"# Active Context\n\n"
+        f"**Last Updated**: {today}\n"
+        f"**Current Goal**: {soul_purpose}\n\n"
+        f"## Current Session\n"
+        f"- **Started**: {today}\n"
+        f"- **Focus**: {soul_purpose}\n"
+        f"- **Status**: Initialized\n\n"
+        f"## Progress\n"
+        f"- [x] Session initialized via /start\n"
+        f"- [ ] Begin working on soul purpose\n\n"
+        f"## Notes\n"
+        f"- Soul purpose established: {today}\n"
+        f"- Ralph Loop preference: {ralph_mode}\n"
+        f"- Ralph Loop intensity: {ralph_intensity or 'N/A'}\n"
+    )
+
+    created = [f for f in SESSION_FILES if (sd / f).is_file()]
+    return {
+        "status": "ok",
+        "files_created": len(created),
+        "expected": len(SESSION_FILES),
+    }
+
+
+# ---------------------------------------------------------------------------
+# validate
+# ---------------------------------------------------------------------------
+
+def validate(project_dir: str) -> dict:
+    """Validate session-context files, repair from templates if needed."""
+    sd = session_dir(project_dir)
+    if not sd.is_dir():
+        return {"status": "error", "message": "session-context/ does not exist"}
+
+    results: dict = {"repaired": [], "ok": [], "failed": []}
+
+    for f in SESSION_FILES:
+        path = sd / f
+        if path.is_file() and path.stat().st_size > 0:
+            results["ok"].append(f)
+        else:
+            src = TEMPLATE_DIR / f
+            if src.is_file():
+                shutil.copy2(src, path)
+                results["repaired"].append(f)
+            else:
+                results["failed"].append(f)
+
+    results["status"] = "ok" if not results["failed"] else "partial"
+    return results
+
+
+# ---------------------------------------------------------------------------
+# cache_governance
+# ---------------------------------------------------------------------------
+
+def cache_governance(project_dir: str) -> dict:
+    """Extract governance sections from CLAUDE.md, save to temp cache."""
+    cmd = claude_md(project_dir)
+    if not cmd.is_file():
+        return {"status": "error", "message": "CLAUDE.md not found"}
+
+    content = cmd.read_text()
+    sections = parse_md_sections(content)
+
+    cached: dict[str, str] = {}
+    governance_keys = list(GOVERNANCE_SECTIONS.keys())
+
+    for key in governance_keys:
+        _, body = find_section(sections, key)
+        if body:
+            cached[key] = body
+
+    GOVERNANCE_CACHE_PATH.write_text(json.dumps(cached, indent=2))
+    return {
+        "status": "ok",
+        "cached_sections": list(cached.keys()),
+        "missing_sections": [k for k in governance_keys if k not in cached],
+        "cache_file": str(GOVERNANCE_CACHE_PATH),
+    }
+
+
+# ---------------------------------------------------------------------------
+# restore_governance
+# ---------------------------------------------------------------------------
+
+def restore_governance(project_dir: str) -> dict:
+    """Restore governance sections to CLAUDE.md from cache."""
+    cmd = claude_md(project_dir)
+
+    if not cmd.is_file():
+        template = TEMPLATE_DIR / "CLAUDE-mdReference.md"
+        if template.is_file():
+            shutil.copy2(template, cmd)
+        else:
+            return {"status": "error", "message": "CLAUDE.md and template both missing"}
+
+    if not GOVERNANCE_CACHE_PATH.is_file():
+        return {"status": "error", "message": "No governance cache found. Run cache-governance first."}
+
+    cached = json.loads(GOVERNANCE_CACHE_PATH.read_text())
+    content = cmd.read_text()
+    sections = parse_md_sections(content)
+
+    restored: list[str] = []
+    for key, cached_content in cached.items():
+        heading, _ = find_section(sections, key)
+        if heading is None:
+            content = content.rstrip() + f"\n\n---\n\n{cached_content}\n"
+            restored.append(key)
+
+    if restored:
+        cmd.write_text(content)
+
+    GOVERNANCE_CACHE_PATH.unlink(missing_ok=True)
+
+    return {
+        "status": "ok",
+        "restored": restored,
+        "already_present": [k for k in cached if k not in restored],
+    }
+
+
+# ---------------------------------------------------------------------------
+# ensure_governance
+# ---------------------------------------------------------------------------
+
+def ensure_governance(
+    project_dir: str,
+    ralph_mode: str = "Manual",
+    ralph_intensity: str = "",
+) -> dict:
+    """Ensure all governance sections exist in CLAUDE.md."""
+    cmd = claude_md(project_dir)
+
+    if not cmd.is_file():
+        template = TEMPLATE_DIR / "CLAUDE-mdReference.md"
+        if template.is_file():
+            shutil.copy2(template, cmd)
+        else:
+            cmd.write_text("# CLAUDE.md\n\nThis file provides guidance to Claude Code.\n")
+
+    content = cmd.read_text()
+    sections = parse_md_sections(content)
+
+    added: list[str] = []
+    for key, template_content in GOVERNANCE_SECTIONS.items():
+        heading, _ = find_section(sections, key)
+        if heading is None:
+            section_text = template_content.format(
+                ralph_mode=ralph_mode,
+                ralph_intensity=ralph_intensity or "N/A",
+            )
+            content = content.rstrip() + f"\n\n---\n\n{section_text}\n"
+            added.append(key)
+
+    if added:
+        cmd.write_text(content)
+
+    return {
+        "status": "ok",
+        "added": added,
+        "already_present": [k for k in GOVERNANCE_SECTIONS if k not in added],
+    }
+
+
+# ---------------------------------------------------------------------------
+# read_context
+# ---------------------------------------------------------------------------
+
+def read_context(project_dir: str) -> dict:
+    """Read soul purpose + active context, return structured summary."""
+    sd = session_dir(project_dir)
+    cmd = claude_md(project_dir)
+
+    result: dict = {
+        "soul_purpose": "",
+        "has_archived_purposes": False,
+        "active_context_summary": "",
+        "open_tasks": [],
+        "recent_progress": [],
+        "status_hint": "unknown",
+        "ralph_mode": "",
+        "ralph_intensity": "",
+    }
+
+    # Read soul purpose
+    sp_file = sd / "CLAUDE-soul-purpose.md"
+    if sp_file.is_file():
+        sp_content = sp_file.read_text()
+        lines = sp_content.split("\n")
+        purpose_lines: list[str] = []
+        for line in lines:
+            if "[CLOSED]" in line:
+                result["has_archived_purposes"] = True
+                break
+            if (
+                line.strip()
+                and not line.startswith("#")
+                and line.strip() != "---"
+                and not line.strip().startswith("<!--")
+            ):
+                purpose_lines.append(line.strip())
+        result["soul_purpose"] = " ".join(purpose_lines).strip()
+
+        if "(No active soul purpose)" in sp_content or not result["soul_purpose"]:
+            result["soul_purpose"] = ""
+            result["status_hint"] = "no_purpose"
+
+    # Read active context (first 60 lines)
+    ac_file = sd / "CLAUDE-activeContext.md"
+    if ac_file.is_file():
+        ac_content = ac_file.read_text()
+        ac_lines = ac_content.split("\n")[:60]
+        result["active_context_summary"] = "\n".join(ac_lines)
+
+        for line in ac_content.split("\n"):
+            stripped = line.strip()
+            if "[ ]" in stripped:
+                result["open_tasks"].append(stripped.lstrip("- "))
+            elif "[x]" in stripped.lower():
+                result["recent_progress"].append(stripped.lstrip("- "))
+
+    # Extract ralph config from CLAUDE.md
+    if cmd.is_file():
+        md_content = cmd.read_text()
+        md_sections = parse_md_sections(md_content)
+        _, ralph_body = find_section(md_sections, "Ralph Loop")
+        if ralph_body:
+            for line in ralph_body.split("\n"):
+                if line.strip().startswith("**Mode**:"):
+                    result["ralph_mode"] = line.split("**Mode**:")[1].strip().lower()
+                elif line.strip().startswith("**Intensity**:"):
+                    result["ralph_intensity"] = line.split("**Intensity**:")[1].strip()
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# harvest
+# ---------------------------------------------------------------------------
+
+def harvest(project_dir: str) -> dict:
+    """Scan active context for promotable content."""
+    sd = session_dir(project_dir)
+    ac_file = sd / "CLAUDE-activeContext.md"
+    if not ac_file.is_file():
+        return {"status": "nothing", "message": "No active context file."}
+
+    ac_content = ac_file.read_text()
+    template_path = TEMPLATE_DIR / "CLAUDE-activeContext.md"
+    template = template_path.read_text() if template_path.is_file() else ""
+
+    if ac_content.strip() == template.strip() or len(ac_content.strip()) < 100:
+        return {"status": "nothing", "message": "Active context is in template state."}
+
+    return {
+        "status": "has_content",
+        "active_context": ac_content,
+        "target_files": {
+            "decisions": str(sd / "CLAUDE-decisions.md"),
+            "patterns": str(sd / "CLAUDE-patterns.md"),
+            "troubleshooting": str(sd / "CLAUDE-troubleshooting.md"),
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# archive
+# ---------------------------------------------------------------------------
+
+def archive(
+    project_dir: str,
+    old_purpose: str,
+    new_purpose: str = "",
+) -> dict:
+    """Archive soul purpose and optionally set new one. Reset active context."""
+    sd = session_dir(project_dir)
+    sp_file = sd / "CLAUDE-soul-purpose.md"
+    if not sp_file.is_file():
+        return {"status": "error", "message": "Soul purpose file not found."}
+
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    existing = sp_file.read_text()
+
+    archived_block = f"## [CLOSED] \u2014 {today}\n\n{old_purpose}\n"
+
+    if new_purpose:
+        new_content = f"# Soul Purpose\n\n{new_purpose}\n\n---\n\n{archived_block}"
+    else:
+        new_content = f"# Soul Purpose\n\n(No active soul purpose)\n\n---\n\n{archived_block}"
+
+    # Preserve existing [CLOSED] entries
+    if "[CLOSED]" in existing:
+        for line in existing.split("\n"):
+            if "[CLOSED]" in line:
+                idx = existing.index(line)
+                old_archives = existing[idx:]
+                new_content = new_content.rstrip() + f"\n\n{old_archives}\n"
+                break
+
+    sp_file.write_text(new_content)
+
+    # Reset active context from template
+    ac_template = TEMPLATE_DIR / "CLAUDE-activeContext.md"
+    ac_file = sd / "CLAUDE-activeContext.md"
+    if ac_template.is_file():
+        shutil.copy2(ac_template, ac_file)
+    else:
+        ac_file.write_text(f"# Active Context\n\n**Last Updated**: {today}\n")
+
+    return {
+        "status": "ok",
+        "archived_purpose": old_purpose[:80] + "..." if len(old_purpose) > 80 else old_purpose,
+        "new_purpose": new_purpose or "(No active soul purpose)",
+        "active_context_reset": True,
+    }
+
+
+# ---------------------------------------------------------------------------
+# check_clutter
+# ---------------------------------------------------------------------------
+
+ROOT_WHITELIST_EXACT = {
+    "claude.md", "readme.md", "license", "license.md", "cname",
+    "package.json", "package-lock.json", "yarn.lock", "pnpm-lock.yaml",
+    "tsconfig.json", "jsconfig.json", "next.config.js", "next.config.mjs",
+    "next.config.ts", "next-env.d.ts", "vercel.json", "netlify.toml",
+    "middleware.ts", "middleware.js", "instrumentation.ts",
+    "tailwind.config.js", "tailwind.config.ts", "tailwind.config.mjs",
+    "postcss.config.js", "postcss.config.mjs", "postcss.config.cjs",
+    "eslint.config.js", "eslint.config.mjs", ".eslintrc.js", ".eslintrc.json",
+    ".prettierrc", ".prettierrc.json", ".prettierrc.js",
+    "dockerfile", "docker-compose.yml", "docker-compose.yaml",
+    ".dockerignore", ".gitignore", ".gitattributes", ".editorconfig",
+    "makefile", "rakefile", "gemfile", "gemfile.lock",
+    "pyproject.toml", "setup.py", "setup.cfg", "requirements.txt",
+    "cargo.toml", "cargo.lock", "go.mod", "go.sum",
+    "sanity.config.ts", "sanity.config.js", "sanity.cli.ts", "sanity.cli.js",
+    "drizzle.config.ts", "drizzle.config.js",
+    "vitest.config.ts", "vitest.config.js", "jest.config.ts", "jest.config.js",
+    "playwright.config.ts", "playwright.config.js",
+    "index.html", "robots.txt", "sitemap.xml",
+    "components.json",
+    "railway.toml", "fly.toml", "render.yaml", "app.yaml",
+    "turbo.json", "nx.json", "lerna.json", "pnpm-workspace.yaml",
+    "vitest.setup.ts", "vitest.setup.js", "jest.setup.ts", "jest.setup.js",
+    "tsconfig.tsbuildinfo",
+    "commitlint.config.js", "lint-staged.config.js", ".lintstagedrc",
+    ".husky", ".changeset",
+    "biome.json", "deno.json", "bun.lockb",
+}
+
+ROOT_WHITELIST_PATTERNS = [
+    ".env", ".npmrc", ".nvmrc", ".node-version",
+    ".python-version", ".tool-versions",
+]
+
+CLUTTER_CATEGORIES = [
+    ({".md"}, "docs/archive", "documentation/reports"),
+    ({".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".ico"}, "docs/screenshots", "screenshots/images"),
+    ({".sh", ".ps1", ".bash"}, "scripts", "shell scripts"),
+    ({".bak", ".orig", ".old"}, None, "backup files (suggest delete)"),
+    ({".log"}, "logs", "log files"),
+    ({".sql"}, "scripts/db", "SQL scripts"),
+    ({".html"}, "docs/reports", "HTML reports"),
+]
+
+
+def _is_whitelisted(filename: str) -> bool:
+    lower = filename.lower()
+    if lower in ROOT_WHITELIST_EXACT:
+        return True
+    for pattern in ROOT_WHITELIST_PATTERNS:
+        if lower.startswith(pattern):
+            return True
+    if filename.startswith("."):
+        return True
+    return False
+
+
+def _categorize_file(filename: str) -> tuple[str | None, str]:
+    suffix = Path(filename).suffix.lower()
+    for extensions, target_dir, description in CLUTTER_CATEGORIES:
+        if suffix in extensions:
+            return target_dir, description
+    return "docs/archive", "uncategorized"
+
+
+def check_clutter(project_dir: str) -> dict:
+    """Scan root directory for files that violate structure rules."""
+    root = Path(project_dir)
+    root_files = sorted(
+        f for f in root.iterdir()
+        if f.is_file() and not f.name.startswith("CLAUDE")
+    )
+
+    clutter: list[dict] = []
+    whitelisted: list[str] = []
+    deletable: list[dict] = []
+
+    for f in root_files:
+        name = f.name
+        if _is_whitelisted(name):
+            whitelisted.append(name)
+            continue
+
+        target_dir, category = _categorize_file(name)
+        if target_dir is None:
+            deletable.append({"file": name, "category": category})
+        else:
+            clutter.append({
+                "file": name,
+                "target": f"{target_dir}/{name}",
+                "category": category,
+            })
+
+    moves_by_dir: dict[str, list[str]] = {}
+    for item in clutter:
+        target = item["target"].rsplit("/", 1)[0]
+        if target not in moves_by_dir:
+            moves_by_dir[target] = []
+        moves_by_dir[target].append(item["file"])
+
+    return {
+        "status": "clean" if not clutter and not deletable else "cluttered",
+        "root_file_count": len(root_files),
+        "whitelisted_count": len(whitelisted),
+        "clutter_count": len(clutter),
+        "deletable_count": len(deletable),
+        "moves": clutter,
+        "moves_by_dir": moves_by_dir,
+        "deletable": deletable,
+        "summary": (
+            f"{len(clutter)} files to move, {len(deletable)} to delete"
+            if clutter or deletable
+            else "Root directory is clean"
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# classify_brainstorm
+# ---------------------------------------------------------------------------
+
+def classify_brainstorm(directive: str, project_signals: dict) -> dict:
+    """Deterministic brainstorm weight classification.
+
+    Codifies the 4-row weight table:
+    - directive (3+ words) + has content → lightweight
+    - directive (3+ words) + empty project → standard
+    - no directive + has content → lightweight
+    - no directive + empty project → full
+    """
+    has_directive = len(directive.split()) >= 3
+    has_content = (
+        project_signals.get("has_readme", False)
+        or project_signals.get("has_code_files", False)
+        or project_signals.get("has_package_json", False)
+        or project_signals.get("has_pyproject", False)
+        or project_signals.get("has_cargo_toml", False)
+        or project_signals.get("has_go_mod", False)
+    )
+
+    if has_directive and has_content:
+        weight = "lightweight"
+    elif has_directive and not has_content:
+        weight = "standard"
+    elif not has_directive and has_content:
+        weight = "lightweight"
+    else:
+        weight = "full"
+
+    return {
+        "weight": weight,
+        "has_directive": has_directive,
+        "has_content": has_content,
+    }
+
+
+# ---------------------------------------------------------------------------
+# hook_activate
+# ---------------------------------------------------------------------------
+
+def hook_activate(project_dir: str, soul_purpose: str) -> dict:
+    """Write lifecycle state to session-context/.lifecycle-active.json.
+
+    Project-scoped (not global ~/.claude/) to prevent cross-project
+    contamination. The stop hook reads this file to warn on exit.
+    """
+    sd = session_dir(project_dir)
+    if not sd.is_dir():
+        return {"status": "error", "message": "session-context/ does not exist"}
+
+    state = {
+        "active": True,
+        "soul_purpose": soul_purpose,
+        "activated_at": datetime.now(timezone.utc).isoformat(),
+        "project_dir": project_dir,
+    }
+
+    state_file = sd / LIFECYCLE_STATE_FILENAME
+    state_file.write_text(json.dumps(state, indent=2))
+
+    return {"status": "ok", "file": str(state_file)}
+
+
+# ---------------------------------------------------------------------------
+# hook_deactivate
+# ---------------------------------------------------------------------------
+
+def hook_deactivate(project_dir: str) -> dict:
+    """Remove lifecycle state file. Idempotent."""
+    sd = session_dir(project_dir)
+    state_file = sd / LIFECYCLE_STATE_FILENAME
+    was_active = state_file.is_file()
+
+    if was_active:
+        state_file.unlink()
+
+    return {"status": "ok", "was_active": was_active}
+
+
+# ---------------------------------------------------------------------------
+# features_read
+# ---------------------------------------------------------------------------
+
+def features_read(project_dir: str) -> dict:
+    """Parse CLAUDE-features.md into structured claims by status.
+
+    Expected format: markdown with checkbox items.
+    - [x] Feature name — verified
+    - [ ] Feature name — pending
+    - [!] Feature name — failed (convention)
+    """
+    sd = session_dir(project_dir)
+    features_file = sd / "CLAUDE-features.md"
+
+    if not features_file.is_file():
+        return {"exists": False, "claims": [], "counts": {}, "total": 0}
+
+    content = features_file.read_text()
+    claims: list[dict] = []
+
+    for line in content.split("\n"):
+        stripped = line.strip()
+        if not stripped.startswith("- "):
+            continue
+
+        if "[x]" in stripped.lower():
+            status = "verified"
+            text = stripped.split("]", 1)[1].strip().lstrip("- ")
+        elif "[!]" in stripped:
+            status = "failed"
+            text = stripped.split("]", 1)[1].strip().lstrip("- ")
+        elif "[ ]" in stripped:
+            status = "pending"
+            text = stripped.split("]", 1)[1].strip().lstrip("- ")
+        else:
+            continue
+
+        claims.append({"text": text, "status": status})
+
+    counts = {
+        "verified": sum(1 for c in claims if c["status"] == "verified"),
+        "pending": sum(1 for c in claims if c["status"] == "pending"),
+        "failed": sum(1 for c in claims if c["status"] == "failed"),
+    }
+
+    return {
+        "exists": True,
+        "claims": claims,
+        "counts": counts,
+        "total": len(claims),
+    }
+
+
+# ---------------------------------------------------------------------------
+# git_summary
+# ---------------------------------------------------------------------------
+
+def git_summary(project_dir: str) -> dict:
+    """Raw git data: recent commits, changed files, branch, ahead/behind.
+
+    Returns deterministic data only — no staleness judgment. The AI
+    compares this against read_context output to decide what to update.
+    """
+    result: dict = {
+        "is_git": False,
+        "branch": "",
+        "commits": [],
+        "files_changed": [],
+        "ahead": 0,
+        "behind": 0,
+    }
+
+    def _run(args: list[str]) -> str | None:
+        try:
+            proc = subprocess.run(
+                args, capture_output=True, text=True, cwd=project_dir,
+                timeout=10,
+            )
+            return proc.stdout.strip() if proc.returncode == 0 else None
+        except (subprocess.SubprocessError, FileNotFoundError):
+            return None
+
+    # Check if git repo
+    if _run(["git", "rev-parse", "--git-dir"]) is None:
+        return result
+    result["is_git"] = True
+
+    # Current branch
+    branch = _run(["git", "rev-parse", "--abbrev-ref", "HEAD"])
+    if branch:
+        result["branch"] = branch
+
+    # Recent commits (last 10)
+    log_output = _run([
+        "git", "log", "--oneline", "--no-decorate", "-10",
+    ])
+    if log_output:
+        result["commits"] = [
+            {"hash": line.split(" ", 1)[0], "message": line.split(" ", 1)[1] if " " in line else ""}
+            for line in log_output.split("\n")
+            if line.strip()
+        ]
+
+    # Changed files (staged + unstaged + untracked)
+    status_output = _run(["git", "status", "--porcelain"])
+    if status_output:
+        result["files_changed"] = [
+            {"status": line[:2].strip(), "file": line[3:]}
+            for line in status_output.split("\n")
+            if line.strip()
+        ]
+
+    # Ahead/behind tracking branch
+    tracking = _run([
+        "git", "rev-list", "--left-right", "--count", "HEAD...@{upstream}",
+    ])
+    if tracking and "\t" in tracking:
+        parts = tracking.split("\t")
+        result["ahead"] = int(parts[0])
+        result["behind"] = int(parts[1])
+
+    return result

--- a/src/atlas_session/session/tools.py
+++ b/src/atlas_session/session/tools.py
@@ -1,0 +1,129 @@
+"""Session lifecycle MCP tool definitions.
+
+Each tool wraps an operation from operations.py, exposing it as a
+FastMCP tool with typed parameters and structured JSON output.
+"""
+
+from fastmcp import FastMCP
+
+from . import operations as ops
+
+
+def register(mcp: FastMCP) -> None:
+    """Register all session tools on the given server."""
+
+    @mcp.tool
+    def session_preflight(project_dir: str) -> dict:
+        """Detect environment: mode (init/reconcile), git status, project
+        signals, template validity, session file health. Call this first
+        to determine which workflow to follow."""
+        return ops.preflight(project_dir)
+
+    @mcp.tool
+    def session_init(
+        project_dir: str,
+        soul_purpose: str,
+        ralph_mode: str = "Manual",
+        ralph_intensity: str = "",
+    ) -> dict:
+        """Bootstrap session-context/ with templates, soul purpose, and
+        active context. Creates the session-context directory and seeds
+        all required files."""
+        return ops.init(project_dir, soul_purpose, ralph_mode, ralph_intensity)
+
+    @mcp.tool
+    def session_validate(project_dir: str) -> dict:
+        """Validate session-context files exist and have content.
+        Repairs missing files from templates automatically."""
+        return ops.validate(project_dir)
+
+    @mcp.tool
+    def session_read_context(project_dir: str) -> dict:
+        """Read soul purpose, active context summary, open/completed tasks,
+        Ralph config, and status hint. Primary tool for understanding
+        current session state."""
+        return ops.read_context(project_dir)
+
+    @mcp.tool
+    def session_harvest(project_dir: str) -> dict:
+        """Scan active context for content worth promoting to decisions,
+        patterns, or troubleshooting files. Returns raw content for AI
+        judgment on what qualifies."""
+        return ops.harvest(project_dir)
+
+    @mcp.tool
+    def session_archive(
+        project_dir: str,
+        old_purpose: str,
+        new_purpose: str = "",
+    ) -> dict:
+        """Archive current soul purpose with [CLOSED] marker and optionally
+        set a new one. Resets active context from template."""
+        return ops.archive(project_dir, old_purpose, new_purpose)
+
+    @mcp.tool
+    def session_check_clutter(project_dir: str) -> dict:
+        """Scan project root for misplaced files. Returns categorized
+        move map (docs, scripts, images) and deletable backup files."""
+        return ops.check_clutter(project_dir)
+
+    @mcp.tool
+    def session_cache_governance(project_dir: str) -> dict:
+        """Cache governance sections from CLAUDE.md to /tmp before
+        running /init (which may overwrite CLAUDE.md)."""
+        return ops.cache_governance(project_dir)
+
+    @mcp.tool
+    def session_restore_governance(project_dir: str) -> dict:
+        """Restore cached governance sections to CLAUDE.md after /init.
+        Must call session_cache_governance first."""
+        return ops.restore_governance(project_dir)
+
+    @mcp.tool
+    def session_ensure_governance(
+        project_dir: str,
+        ralph_mode: str = "Manual",
+        ralph_intensity: str = "",
+    ) -> dict:
+        """Ensure all required governance sections exist in CLAUDE.md.
+        Adds missing Structure Maintenance, Session Context, Template,
+        and Ralph Loop sections."""
+        return ops.ensure_governance(project_dir, ralph_mode, ralph_intensity)
+
+    @mcp.tool
+    def session_classify_brainstorm(
+        directive: str,
+        project_signals: dict,
+    ) -> dict:
+        """Deterministic brainstorm weight classification. Returns
+        lightweight/standard/full based on directive presence and
+        project content signals from preflight."""
+        return ops.classify_brainstorm(directive, project_signals)
+
+    @mcp.tool
+    def session_hook_activate(
+        project_dir: str,
+        soul_purpose: str,
+    ) -> dict:
+        """Write lifecycle state to session-context/.lifecycle-active.json.
+        Project-scoped file used by stop hook to warn on unclean exit."""
+        return ops.hook_activate(project_dir, soul_purpose)
+
+    @mcp.tool
+    def session_hook_deactivate(project_dir: str) -> dict:
+        """Remove lifecycle state file. Idempotent. Call during
+        settlement or session close."""
+        return ops.hook_deactivate(project_dir)
+
+    @mcp.tool
+    def session_features_read(project_dir: str) -> dict:
+        """Parse CLAUDE-features.md into structured claims by status
+        (verified/pending/failed). Returns {exists, claims[], counts, total}."""
+        return ops.features_read(project_dir)
+
+    @mcp.tool
+    def session_git_summary(project_dir: str) -> dict:
+        """Raw git data: recent commits, changed files, branch, ahead/behind.
+        Deterministic — no comparison or judgment. AI compares against
+        read_context to detect stale context."""
+        return ops.git_summary(project_dir)

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "atlas-session-lifecycle"
+version = "4.0.0"
+description = "MCP server for AI session lifecycle management"
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.10"
+dependencies = [
+    "fastmcp>=2.0",
+    "httpx>=0.27",
+]
+
+[project.scripts]
+atlas-session = "atlas_session.server:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]


### PR DESCRIPTION
## Summary
- Brings the atlas-session MCP server source into version control (was only at `~/.claude/skills/start/src/`)
- Adds 5 new deterministic session tools: `session_classify_brainstorm`, `session_hook_activate`, `session_hook_deactivate`, `session_features_read`, `session_git_summary`
- Updates `install.sh` to deploy `src/` alongside SKILL.md on install
- Updates stop hook to use project-scoped lifecycle state (`session-context/.lifecycle-active.json`)
- Total MCP tools: 23 (10 existing session + 5 new + 8 contract)

## Test plan
- [x] `python3 -c "from atlas_session.server import mcp"` starts, 23 tools register
- [x] `session_classify_brainstorm("build a chat app", {"has_readme": true})` returns `{weight: "lightweight"}`
- [x] `session_classify_brainstorm("", {"is_empty_project": true})` returns `{weight: "full"}`
- [x] `session_hook_activate` creates `.lifecycle-active.json` in `session-context/`
- [x] `session_hook_deactivate` removes it (idempotent)
- [x] `session_git_summary` returns recent commits + changed files
- [x] `session_features_read` returns `{exists: false}` when no features file
- [x] Existing tools unchanged, backward-compatible

🤖 Generated with [Claude Code](https://claude.com/claude-code)